### PR TITLE
Add CairoSVG Exporter

### DIFF
--- a/examples/brochure/main.rs
+++ b/examples/brochure/main.rs
@@ -1,7 +1,9 @@
 use color_eyre::{eyre::Report, Result};
 use std::path::Path;
-use svggloo::setup;
-use svggloo::template::render;
+use svggloo::{
+    setup,
+    template::{render, Exporter},
+};
 
 // The paths must be relative to the Cargo.toml file.
 const SVG_TEMPLATE_FILENAME: &'static str = "examples/brochure/brochure.svg";
@@ -19,7 +21,13 @@ fn main() -> Result<(), Report> {
 
     // Render the template.
     let fields = vec![String::from("co"), String::from("st"), String::from("ci")];
-    let _ = render(&svg_template, output_dir, true, Some(fields), None)?;
+    let _ = render(
+        &svg_template,
+        output_dir,
+        Some(Exporter::CairoSVG),
+        Some(fields),
+        None,
+    )?;
 
     Ok(())
 }

--- a/examples/quantifier/main.rs
+++ b/examples/quantifier/main.rs
@@ -1,7 +1,9 @@
 use color_eyre::{eyre::Report, Result};
 use std::path::Path;
-use svggloo::setup;
-use svggloo::template::render;
+use svggloo::{
+    setup,
+    template::{render, Exporter},
+};
 
 // The paths must be relative to the Cargo.toml file.
 const SVG_TEMPLATE_FILENAME: &'static str = "examples/quantifier/bike_lane_categories.svg";
@@ -23,7 +25,13 @@ fn main() -> Result<(), Report> {
         String::from("state"),
         String::from("city"),
     ];
-    let _ = render(&svg_template, output_dir, true, Some(fields), None)?;
+    let _ = render(
+        &svg_template,
+        output_dir,
+        Some(Exporter::Inkscape),
+        Some(fields),
+        None,
+    )?;
 
     Ok(())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,4 @@
+use crate::template::Exporter;
 use clap::{crate_name, Parser, ValueHint};
 use std::path::PathBuf;
 
@@ -26,6 +27,6 @@ pub struct Opts {
     #[clap(short, long, default_value = "-")]
     pub separator: String,
     /// Export the rendered template as PDF
-    #[clap(short, long)]
-    pub export: bool,
+    #[clap(short, long, arg_enum)]
+    pub exporter: Option<Exporter>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), Report> {
     let _ = render(
         &opts.template,
         &opts.output_dir,
-        opts.export,
+        opts.exporter,
         opts.field,
         Some(&opts.separator),
     );


### PR DESCRIPTION
Adds the ability to use `cairosvg` as an exporter.
